### PR TITLE
added net host flag to docker run to allow for proper host name resol…

### DIFF
--- a/src/ansible/deploy.yaml
+++ b/src/ansible/deploy.yaml
@@ -9,7 +9,7 @@
   gather_facts: false
   vars:
     skip_worker_play: '{{ skip_worker | default(false) }}'
-    remote_worker_path: '{{ ansible_env.HOME }}/moneo-worker'
+    remote_worker_path: '/tmp/moneo-worker'
   tasks:
   - when: not skip_worker_play
     block:

--- a/src/ansible/grafana.config.j2
+++ b/src/ansible/grafana.config.j2
@@ -9,7 +9,7 @@ datasources:
     type: prometheus
     access: proxy
     orgId: 1
-    url: http://{{ ansible_env['SSH_CLIENT'].split() | first }}:9090
+    url: http://{{ ansible_facts['nodename'] }}:9090
     isDefault: true
     jsonData:
       timeInterval: 1s

--- a/src/master/run.sh
+++ b/src/master/run.sh
@@ -4,7 +4,7 @@
 mkdir -m 777 /mnt/prometheus
 docker rm -f prometheus || true
 docker run --name prometheus \
-    -it -d -p 9090:9090 \
+    -it --net=host -d -p 9090:9090 \
     -v /mnt/prometheus:/prometheus \
     -v $PWD/prometheus.yml:/etc/prometheus/prometheus.yml \
     prom/prometheus \
@@ -17,7 +17,7 @@ docker run --name prometheus \
 # start grafana
 docker rm -f grafana || true
 docker run --name grafana \
-    -it -d -p 3000:3000 \
+    -it --net=host  -d -p 3000:3000 \
     --env-file $PWD/grafana/grafana.env \
     -v $PWD/grafana/dashboards:/var/lib/grafana/dashboards \
     -v $PWD/grafana/provisioning:/etc/grafana/provisioning \


### PR DESCRIPTION
Cycle Cloud fixes:
- Add --net=host to the docker run commands, to allow for hostname resolutions
- Modified the Moneo worker remote path to be tmp directory in the event of using a shared home drive. 
- Reverted grafana config back to original.