### PR TITLE
Create /tmp/moneo-worker folder in exporters

### DIFF
--- a/src/worker/exporters/net_exporter.py
+++ b/src/worker/exporters/net_exporter.py
@@ -202,6 +202,7 @@ def get_log_level(loglevel):
 
 def main(args):
     # set up logging
+    os.makedirs('/tmp/moneo-worker', exist_ok=True)
     logging.basicConfig(level=get_log_level(args.log_level), filename='/tmp/moneo-worker/moneoExporter.log',
                         format='[%(asctime)s] net_exporter-%(levelname)s-%(message)s')
     jobId = None

--- a/src/worker/exporters/node_exporter.py
+++ b/src/worker/exporters/node_exporter.py
@@ -392,6 +392,7 @@ def main():
         help='Port to export metrics from')
     args = parser.parse_args()
     # set up logging
+    os.makedirs('/tmp/moneo-worker', exist_ok=True)
     logging.basicConfig(level=get_log_level(args), filename='/tmp/moneo-worker/moneoExporter.log',
                         format='[%(asctime)s] node_exporter-%(levelname)s-%(message)s')
     jobId = None  # set a default job id of None

--- a/src/worker/exporters/nvidia_exporter.py
+++ b/src/worker/exporters/nvidia_exporter.py
@@ -314,6 +314,7 @@ def parse_dcgm_cli():
     numeric_log_level = dcgm_client_cli_parser.get_log_level(args)
     filemode = 'w+'
     if not args.logfile:
+        os.makedirs('/tmp/moneo-worker', exist_ok=True)
         args.logfile = '/tmp/moneo-worker/moneoExporter.log'
         filemode = 'a'
     # Defaults to localhost, so we need to set it to None.


### PR DESCRIPTION
When using Moneo in docker container, the folder /tmp/moneo-worker doesn't exist, which will crash the exporter. We need to create this folder before using it.