### PR TITLE
Fix the Geneva MDM endpoint settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 #config files
 *.ini
+
+# IDE
+.vs/

--- a/src/worker/start_geneva.sh
+++ b/src/worker/start_geneva.sh
@@ -18,7 +18,7 @@ GENEVA_MDM_ENDPOINT=$(jq -r '.MDMEndPoint' $GENEVA_CONFIG)
 if [[ "$GENEVA_MDM_ENDPOINT" == *"ppe"* ]]; then
   METRIC_ENDPOINT="https://global.ppe.microsoftmetrics.com/"
 elif [[ "$GENEVA_MDM_ENDPOINT" == *"prod"* ]]; then
-  METRIC_ENDPOINT="https://global.prod.microsoftmetrics.com/"
+  METRIC_ENDPOINT=""
 else
     echo "Invalid Geneva Metrics Extension(MA) Endpoint"
     exit 1
@@ -49,6 +49,7 @@ EOF
                     -v $GENEVA_DIR:/etc/geneva/ -e MDM_ACCOUNT=$GENEVA_ACCOUNT_NAME     \
                     -e MDM_INPUT="otlp_grpc,statsd_udp" -e MDM_LOG_LEVEL="info"         \
                     -e CONFIG_OVERRIDES_FILE="/etc/geneva/auth_umi.json"                \
+                    -e METRIC_ENDPOINT=$METRIC_ENDPOINT                                 \
                     genevamdm
 elif [ $AUTH == "cert" ];
 then

--- a/src/worker/start_geneva.sh
+++ b/src/worker/start_geneva.sh
@@ -17,7 +17,7 @@ GENEVA_MDM_ENDPOINT=$(jq -r '.MDMEndPoint' $GENEVA_CONFIG)
 # Set Geneva Metrics Extension(MA) endpoint
 if [[ "$GENEVA_MDM_ENDPOINT" == *"ppe"* ]]; then
   METRIC_ENDPOINT="https://global.ppe.microsoftmetrics.com/"
-elif [[ $str == *"prod"* ]]; then
+elif [[ "$GENEVA_MDM_ENDPOINT" == *"prod"* ]]; then
   METRIC_ENDPOINT="https://global.prod.microsoftmetrics.com/"
 else
     echo "Invalid Geneva Metrics Extension(MA) Endpoint"
@@ -49,7 +49,6 @@ EOF
                     -v $GENEVA_DIR:/etc/geneva/ -e MDM_ACCOUNT=$GENEVA_ACCOUNT_NAME     \
                     -e MDM_INPUT="otlp_grpc,statsd_udp" -e MDM_LOG_LEVEL="info"         \
                     -e CONFIG_OVERRIDES_FILE="/etc/geneva/auth_umi.json"                \
-                    -e METRIC_ENDPOINT=$METRIC_ENDPOINT                                 \
                     genevamdm
 elif [ $AUTH == "cert" ];
 then


### PR DESCRIPTION
1. Fix a typo when checking if the Geneva MDM endpoint contains "prod"
2. Set the "METRIC_ENDPOINT" env var to empty for prod so that the default endpoint will be used (refer to the following error message). 

For # 2, when we try to start the Docker image with prod endpoint, the `genevamdm` says:
```
You passed in value: https://global.prod.microsoftmetrics.com/
The only supported values are https://global.int.microsoftmetrics.com/, https://az-int.metrics.nsatc.net/, https://az-int.int.microsoftmetrics.com/, https://global.ppe.microsoftmetrics.com/ and it should only be used for accessing int or ppe configuration environments.

If you've used any other option pointing to a specific stamp in the past, please remove it - it should work with default prod configuration environment.
```
As we tested, it worked fine if we use an empty string for prod.