### PR TITLE
Handle exception when publishing logs to Geneva

### DIFF
--- a/src/worker/exporters/base_exporter.py
+++ b/src/worker/exporters/base_exporter.py
@@ -83,7 +83,10 @@ class BaseExporter:
                 if (job_update):
                     self.jobID_update()
                     job_update = False
-                self.process()
+                try:
+                    self.process()
+                except:
+                    logging.exception('Error while processing metrics')
                 time.sleep(self.config['update_freq'])
                 if self.config['exit']:
                     logging.info('Received exit signal, shutting down ...')

--- a/src/worker/publisher/metrics_publisher.py
+++ b/src/worker/publisher/metrics_publisher.py
@@ -295,7 +295,7 @@ if __name__ == '__main__':
         try:
             raw_metrics = metricsPublisher.get_metrics()
             metricsPublisher.publish_metrics(raw_metrics)
-        except URLError as e:
+        except URLError:
             logger.exception('Network connection issue.')
         except:
             logger.exception('Failed to retrieve and publish metrics to Geneva.')

--- a/src/worker/start.sh
+++ b/src/worker/start.sh
@@ -50,7 +50,7 @@ then
             fi
         fi
         sleep 5
-        nohup python3  $WORK_DIR/publisher/metrics_publisher.py $START_PUBLISHER </dev/null >/dev/null 2>&1 &
+        nohup python3  $WORK_DIR/publisher/metrics_publisher.py $START_PUBLISHER >> /tmp/metrics_publisher.log 2>&1 &
     else
         echo "Publisher not supported"
     fi


### PR DESCRIPTION
We have a test cluster with 2 VMs, the Geneva metrics publisher failed after running for a day. We added logs and found that:
```
Traceback (most recent call last):
  File "/tmp/moneo-worker/publisher/metrics_publisher.py", line 292, in <module>
    raw_metrics = metricsPublisher.get_metrics()
  File "/tmp/moneo-worker/publisher/metrics_publisher.py", line 165, in get_metrics
    response = urllib.request.urlopen(metrics_url)
  File "/usr/lib/python3.8/urllib/request.py", line 222, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.8/urllib/request.py", line 525, in open
    response = self._open(req, data)
  File "/usr/lib/python3.8/urllib/request.py", line 542, in _open
    result = self._call_chain(self.handle_open, protocol, protocol +
File "/usr/lib/python3.8/urllib/request.py", line 502, in _call_chain
result = func(*args)
File "/usr/lib/python3.8/urllib/request.py", line 1383, in http_open
return self.do_open(http.client.HTTPConnection, req)
File "/usr/lib/python3.8/urllib/request.py", line 1357, in do_open
raise URLError(err)
urllib.error.URLError: <urlopen error [Errno 111] Connection refused>
```

It's some transient issue that caused an exception when the publisher tried to get metrics from the local endpoint. To prevent the process from crashing, we can handle and log the exception. `logger.exception` will print out the stack trace by default.

Also, we found that if a command times out, the `shell_cmd` returns a result of string "TimeOut", it'll cause errors in quite a few places in `node_exporter.py`. The easiest fix is to handle it in the `base_exporter`.