### PR TITLE
Azure Managed Prometheus Integration to Support In-time Online Monitoring with Second Granularity

### DIFF
--- a/docs/AzurePrometheusAgent.md
+++ b/docs/AzurePrometheusAgent.md
@@ -1,0 +1,63 @@
+Azure Prometheus Agent User Guide (Preview)
+=====
+Description
+-----
+This guide will provide step-by-step instructions on how to use Azure Management to publish your exporter metrics in a second-level granularity interval.
+
+Prequisites:
+1. An Azure Monitor Workspace (AWM), a.k.a Azure Managed Prometheus resource.
+2. Authentication
+    User Managed Identity (umi)
+    - Create an umi on azure portal, register umi object id on geneva portal with a metricsPublisher role, and add the Moneo service princple to the VM/VMSS
+    - Navigate to your VM/VMSS resource on the portal.
+    - From the left menu select "identity" ![image](https://user-images.githubusercontent.com/70273488/227347854-89a1fbaa-d9ca-4694-97fa-cac2fd59ea6f.png)
+    - From the top tabs select "User assigned"
+    - Then click on "Add" this will open a blade to search for the managed identities.
+    - search and select "moneo-umi".
+    - Click add at the bottom of the open blade.
+2. PSSH installed on manager nodes.
+3. Ensure passwordless ssh is installed in you environment.
+4. Config sidecar config file in `Moneo/src/master/sidecar_config.json`.
+    Note: You can obtain your IDENTITY_CLIENT_ID in your indentity resource page and your metrics ingestion endpoint from the AWM pages you created in the Azure portal.
+    ```
+        {
+            "IDENTITY_CLIENT_ID": "<identity client id>",
+            "INGESTION_ENDPOINT": "<metrics ingestion endpoint>"
+        }
+    ```
+Steps
+-----
+1. Ensure that all prequisites are met.
+2. deploy Moneo:
+  - Full deployment 
+  
+    ```python3 moneo.py -d full --enable_prometheus -c ~/hostfile --manager_host localhost```
+  - Master deployment
+  
+     ```python3 moneo.py -d master --enable_prometheus -c ~/hostfile```
+
+    Note: if install step has already been performed you can use the -w flag to skip it.
+3. Verify functionality of prometheus agent remote write :
+    
+    a. Check prometheus docker with `sudo docker logs prometheus | grep 8081`
+    It will have the result like this:
+    ```
+        ts=2023-04-26T10:20:21.722Z caller=dedupe.go:112 component=remote level=info remote_name=c35834 url=http://localhost:8081/api/v1/write msg="Starting WAL watcher" queue=c35834
+
+        ts=2023-04-26T10:20:21.722Z caller=dedupe.go:112 component=remote level=info remote_name=c35834 url=http://localhost:8081/api/v1/write msg="Starting scraped metadata watcher"
+
+        ts=2023-04-26T10:20:21.722Z caller=dedupe.go:112 component=remote level=info remote_name=c35834 url=http://localhost:8081/api/v1/write msg="Replaying WAL" queue=c35834
+
+        ts=2023-04-26T10:20:27.156Z caller=dedupe.go:112 component=remote level=info remote_name=c35834 url=http://localhost:8081/api/v1/write msg="Done replaying WAL" duration=5.434237136s   
+    ```
+    Which means, prometheus agent 's remote write function is enabled to port 8081.
+    
+    b. Check the sidecar docker's status with `netstat -tupln | grep 8081`
+
+    It will have the result like this:
+    ```
+        tcp6       0      0 :::8081                 :::*                    LISTEN      -    
+    ```
+    Which means, port 8081 is under listening by prometheus sidecar docker.
+4. At this point the remote write functionality shoud be working.
+5. Check with Azure grafana (linked with AMW )dashboards to verify that the metrics are being ingested.

--- a/moneo.py
+++ b/moneo.py
@@ -80,7 +80,12 @@ class MoneoCLI:
                     self.args.fork_processes)
 
         if self.args.type == 'manager' or self.args.type == 'full':
-            self.deploy_manager(self.args.host_file, user=self.args.user, manager_host=self.args.manager_host, export_Prometheus=self.args.enable_prometheus)
+            self.deploy_manager(
+                self.args.host_file,
+                user=self.args.user,
+                manager_host=self.args.manager_host,
+                export_Prometheus=self.args.enable_prometheus
+            )
         logging.info('Moneo starting, Deployment type: ' + self.args.type)
 
     def stop(self):
@@ -197,7 +202,14 @@ class MoneoCLI:
         else:
             logging.info(result)
 
-    def deploy_manager(self, work_host_file, user=None, manager_host='localhost', export_AzInsight=False, export_Prometheus=False):
+    def deploy_manager(
+        self,
+        work_host_file,
+        user=None,
+        manager_host='localhost',
+        export_AzInsight=False,
+        export_Prometheus=False
+    ):
         ssh_host = manager_host
         if user:
             ssh_host = "{}@{}".format(user, manager_host)

--- a/src/master/prometheus.yml
+++ b/src/master/prometheus.yml
@@ -1,7 +1,11 @@
 global:
   scrape_interval: 1s
   evaluation_interval: 1s
-
+  external_labels:
+    subscription: subscription_id
+    cluster: cluster_name
+remote_write:
+  - url: "http://localhost:8081/api/v1/write"
 scrape_configs:
   - job_name: 'dcgm_exporter'
     static_configs:

--- a/src/master/shutdown.sh
+++ b/src/master/shutdown.sh
@@ -2,4 +2,5 @@
 
 docker rm -f prometheus || true
 docker rm -f grafana || true
+docker rm -f prometheus_sidecar || true
 pkill -f "azinsights_main.py*" || true

--- a/src/master/sidecar_config.json
+++ b/src/master/sidecar_config.json
@@ -1,0 +1,4 @@
+{
+    "IDENTITY_CLIENT_ID": "<identity client id>",
+    "INGESTION_ENDPOINT": "<metrics ingestion endpoint>"
+}

--- a/src/master/start_sidecar.sh
+++ b/src/master/start_sidecar.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+get_cluster_name(){
+    cluster_name=$(curl -s -H Metadata:true "http://169.254.169.254/metadata/instance/compute/name?api-version=2021-02-01&format=text" | cut -d'_' -f1)
+
+    echo $cluster_name
+}
+
+WORK_DIR=/tmp/moneo-master
+SIDECAR_CONFIG=$WORK_DIR/'sidecar_config.json'
+SIDECAR_VERSION='prom-remotewrite-20230323.1'
+SIDERCAR_DOCKER='mcr.microsoft.com/azuremonitor/prometheus/promdev/prom-remotewrite:'$SIDECAR_VERSION
+
+CLUSTER_NAME=$(get_cluster_name)
+IDENTITY_CLIENT_ID=$(jq -r '.IDENTITY_CLIENT_ID' $SIDECAR_CONFIG)
+INGESTION_ENDPOINT=$(jq -r '.INGESTION_ENDPOINT' $SIDECAR_CONFIG)
+
+echo "CLUSTER_NAME: $CLUSTER_NAME"
+echo "IDENTITY_CLIENT_ID: $IDENTITY_CLIENT_ID"
+echo "INGESTION_ENDPOINT: $INGESTION_ENDPOINT"
+echo "SIDERCAR_DOCKER: $SIDERCAR_DOCKER"
+# pull sidecar image
+docker pull $SIDERCAR_DOCKER
+docker tag  $SIDERCAR_DOCKER prometheus_sidecar
+docker rmi  $SIDERCAR_DOCKER
+
+# start sidecar container
+docker rm -f prometheus_sidecar || true
+sudo docker run --name=prometheus_sidecar \
+    -it --net=host --uts=host -d \
+    -e CLUSTER=$CLUSTER_NAME -e LISTENING_PORT=8081 \
+    -e IDENTITY_TYPE=userAssigned -e AZURE_CLIENT_ID=$IDENTITY_CLIENT_ID \
+    -e INGESTION_URL=$INGESTION_ENDPOINT prometheus_sidecar


### PR DESCRIPTION
Support using Azure Managed Prometheus as the ingestion endpoint to support second granularity monitoring
1. Added `--enable_prometheus` args to enable this feature.
2. Added `prometheus_sidecar` container on the master node to publish Prometheus metrics.
3. Added guidance documentation about how to config and start this feature.